### PR TITLE
feat: Separate CI linting for Makefiles and YAML files

### DIFF
--- a/.github/workflows/lint-makefile.yml
+++ b/.github/workflows/lint-makefile.yml
@@ -1,7 +1,6 @@
 ---
 
-name: Lint YAML & Makefile
-# yamllint disable-line rule:truthy
+name: Lint Makefile
 on:
   pull_request:
     types:
@@ -9,14 +8,8 @@ on:
       - synchronize
       - reopened
     paths:
-      - '**/*.yaml'
       - Makefile
 jobs:
-  lint-yaml:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: frenck/action-yamllint@v1
   lint-makefile:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -1,0 +1,17 @@
+---
+
+name: Lint YAML
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    paths:
+      - '**/*.yaml'
+jobs:
+  lint-yaml:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: frenck/action-yamllint@v1


### PR DESCRIPTION
This commit refactors the CI linting workflow to ensure that:
- Makefile linting only runs when the Makefile changes.
- YAML linting only runs when YAML files change.

Previously, both linting jobs would run if either condition was met. This change improves efficiency by creating separate workflow files for each linting task.